### PR TITLE
use HMAC-SHA-512

### DIFF
--- a/src/system/modules/isotope-wirecard/library/Isotope/Model/Wirecard.php
+++ b/src/system/modules/isotope-wirecard/library/Isotope/Model/Wirecard.php
@@ -117,7 +117,7 @@ class Wirecard extends Postsale implements IsotopePayment {
 			$strParams .= \Input::post($strKey);
 		
 		// calc hash
-		return md5($strParams);
+		return hash_hmac('sha512', $strParams, $this->wirecard_secret);
     }
     
     /**
@@ -133,7 +133,7 @@ class Wirecard extends Postsale implements IsotopePayment {
 			$strParams .= $arrParams[$strKey];
 		
 		// calc hash
-		return md5($strParams);
+		return hash_hmac('sha512', $strParams, $this->wirecard_secret);
     }
 }
 


### PR DESCRIPTION
Wirecard only supports HMAC-SHA-512 now. See https://guides.wirecard.at/request_parameters#requestfingerprint