### PR TITLE
Contao 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	},
 	"autoload": {
         "psr-0": {
-            "Isotope\\": "src/system/modules/isotope/library"
+            "Isotope\\": "src/system/modules/isotope-wirecard/library"
         }
 	},
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
 		"isotope/isotope-core":"^2.0"
 	},
 	"autoload": {
-        "psr-0": {
-            "Isotope\\": "src/system/modules/isotope-wirecard/library"
-        }
+		"psr-0": {
+			"Isotope\\": "src/system/modules/isotope-wirecard/library"
+		}
 	},
-    "replace": {
-        "contao-legacy/isotope_wirecard": "*"
-    },
+	"replace": {
+		"contao-legacy/isotope_wirecard": "*"
+	},
 	"extra":{
 		"contao": {
 			"sources": {

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,21 @@
 	},
 	"require":{
 		"php":">=5.3",
-		"contao/core":"~3.2",
-		"contao-community-alliance/composer-installer":"*",
-		"isotope/isotope-core":">=2.0.0,<2.2"
+		"contao/core-bundle":"^3.2 || ^4.3",
+		"contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
+		"isotope/isotope-core":"^2.0"
 	},
 	"autoload": {
-		"classmap": ["src"]
+        "psr-0": {
+            "Isotope\\": "src/system/modules/isotope/library"
+        }
 	},
     "replace": {
         "contao-legacy/isotope_wirecard": "*"
     },
 	"extra":{
 		"contao": {
-			"symlinks":{
+			"sources": {
 				"src/system/modules/isotope-wirecard":"system/modules/isotope-wirecard"
 			}
 		}

--- a/src/system/modules/isotope-wirecard/config/autoload.ini
+++ b/src/system/modules/isotope-wirecard/config/autoload.ini
@@ -2,7 +2,7 @@
 ; List modules which are required to be loaded beforehand
 ;;
 requires[] = "core"
-requires[] = "_autoload"
+requires[] = "*_autoload"
 requires[] = "isotope"
 
 ;;

--- a/src/system/modules/isotope-wirecard/config/autoload.php
+++ b/src/system/modules/isotope-wirecard/config/autoload.php
@@ -13,7 +13,9 @@
 /**
  * Register PSR-0 namespace
  */
-NamespaceClassLoader::add('Isotope', 'system/modules/isotope-wirecard/library');
+if (class_exists('NamespaceClassLoader')) {
+	NamespaceClassLoader::add('Isotope', 'system/modules/isotope-wirecard/library');
+}
 
 
 /**

--- a/src/system/modules/isotope-wirecard/dca/tl_iso_payment.php
+++ b/src/system/modules/isotope-wirecard/dca/tl_iso_payment.php
@@ -9,10 +9,12 @@
  * @package    isotope-wirecard
  */
 
+
 /**
- * Paletts
+ * Palettes
  */
-$GLOBALS['TL_DCA']['tl_iso_payment']['palettes']['wirecard'] = '{type_legend},name,label,type;{note_legend:hide},note;{config_legend:hide},new_order_status,minimum_total,maximum_total,countries,shipping_modules,product_types;{gateway_legend},wirecard_customer_id,wirecard_secret,wirecard_contact;{price_legend:hide},price,tax_class;{expert_legend:hide},guests,protected;{enabled_legend},enabled';
+$GLOBALS['TL_DCA']['tl_iso_payment']['palettes']['wirecard'] = str_replace('{price_legend', '{gateway_legend},wirecard_customer_id,wirecard_secret,wirecard_contact;{price_legend', $GLOBALS['TL_DCA']['tl_iso_payment']['palettes']['cash']);
+
 
 /**
  * Fields
@@ -47,7 +49,7 @@ array_insert($GLOBALS['TL_DCA']['tl_iso_payment']['fields'], 0, array(
 		'exclude'           => true,
 		'inputType'         => 'pageTree',
 		'foreignKey'        => 'tl_page.title',
-		'eval'              => array('mandatory' => true, 'fieldType' => 'radio'),
+		'eval'              => array('mandatory' => true, 'fieldType' => 'radio', 'tl_class' => 'clr'),
 		'sql'               => "int(10) unsigned NOT NULL default '0'",
 		'relation'          => array('type'=>'hasOne', 'load'=>'lazy'),
 	),


### PR DESCRIPTION
This Pull Requests makes the following changes:

* Change the requirement of `isotope/isotope-core` to `^2.0` to support all Isotope 2.x versions, not just 2.0 and 2.1.
* Change the Contao requirements to be compatible with Contao 4.
* Use PSR-0 class loading for the library folder (just like Isotope).
* Remove the hard dependency on the `_autoload` Extension.
* "Inherit" the palette from `cash`, so that all configs of the current Isotope version are present and just extend it with the gateway specific settings.

These changes have been successfully tested in Contao 4.4.2 with Isotope 2.4.3.