### PR TITLE
Format order->getTotal()

### DIFF
--- a/src/Isotope/Model/Payment/Wirecard.php
+++ b/src/Isotope/Model/Payment/Wirecard.php
@@ -99,7 +99,7 @@ class Wirecard extends Postsale implements IsotopePayment
             'request-id' => $order->getUniqueId(),
             'transaction-type' => self::$paymentMethods[$this->wirecardPaymentMethod],
             'requested-amount' => [
-                'value' => $order->getTotal(),
+                'value' => number_format($order->getTotal(), 2),
                 'currency' => $order->getCurrency(),
             ],
             'payment-methods' => [


### PR DESCRIPTION
Wenn der Warenkorb-Wert z.B. 27,10€ beträgt, gibt $order->getTotal() 27,1 aus, was bei Wirecard zu einem Zahlungsdialog mit Summe 
27,09999999999998€ führt.

![image](https://user-images.githubusercontent.com/1748990/91046027-0a062580-e618-11ea-9e2d-e3eb8fe7590c.png)
